### PR TITLE
Suppress ResizeObserver loop errors in dev overlay

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -89,6 +89,12 @@ module.exports = function (proxy, allowedHost) {
       overlay: {
         errors: true,
         warnings: false,
+        runtimeErrors: (error) => {
+          if (error?.message && /ResizeObserver loop/.test(error.message)) {
+            return false;
+          }
+          return true;
+        },
       },
     },
     devMiddleware: {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangomint/react-scripts",
-  "version": "5.0.1-beta3",
+  "version": "5.0.1-beta4",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add runtimeErrors filter to webpack-dev-server overlay config to suppress benign ResizeObserver loop errors
- These errors are harmless browser noise that trigger the full-screen error overlay during development, blocking the UI

## Details
webpack-dev-server 4.7+ supports a runtimeErrors callback on client.overlay that controls whether a given runtime error is shown in the overlay. This adds a filter that returns false for errors matching ResizeObserver loop, preventing them from triggering the overlay while still showing all other runtime errors.